### PR TITLE
Fix edgecase divide-by-0 in entropy-score

### DIFF
--- a/cleanlab/rank.py
+++ b/cleanlab/rank.py
@@ -440,14 +440,15 @@ def get_confidence_weighted_entropy_for_each_label(
       being correctly labeled.
     """
 
-    MIN_ALLOWED_RAW_SCORE = 1e-6 - 1  # lower-bound clipping threshold to prevent 0 in logarithm
+    MIN_ALLOWED = 1e-6  # lower-bound clipping threshold to prevents 0 in logs and division
     self_confidence = get_self_confidence_for_each_label(labels, pred_probs)
-
+    self_confidence = np.clip(self_confidence, a_min=MIN_ALLOWED, a_max=None)
+    
     # Divide entropy by self confidence
     label_quality_scores = get_normalized_entropy(**{"pred_probs": pred_probs}) / self_confidence
 
     # Rescale
-    label_quality_scores = np.clip(label_quality_scores, a_min=MIN_ALLOWED_RAW_SCORE, a_max=None)
-    label_quality_scores = np.log(label_quality_scores + 1) / label_quality_scores
+    clipped_scores = np.clip(label_quality_scores, a_min=MIN_ALLOWED, a_max=None)
+    label_quality_scores = np.log(label_quality_scores + 1) / clipped_scores
 
     return label_quality_scores


### PR DESCRIPTION
Note:  still some redundant compute/clipping steps in `get_confidence_weighted_entropy_for_each_label()` due to transformations not being analytically calculated out. Current division of the function into entropy() and then confidence_weighted_entropy() is the cause of this as some steps in entropy-calculation are canceled out by confidence_weighted_entropy-rescaling transformation. Likely better to just have confidence_weighted_entropy() be its own function that does not call subroutine beyond self_confidence().